### PR TITLE
Poprawa ewaluacji kwerend

### DIFF
--- a/src/ConcurrentActions/DynamicSystem/QueriesEvaluation/QueriesEvaluator.cs
+++ b/src/ConcurrentActions/DynamicSystem/QueriesEvaluation/QueriesEvaluator.cs
@@ -249,7 +249,7 @@ namespace DynamicSystem.QueriesEvaluation
             {
                 HashSet<State> possibleStates = transitionFunction[action, currentState];
 
-                bool fromEveryStateThereIsAPathToPositiveEnding = true;
+                bool thereIsAPathToPositiveEnding = false;
                 bool atLeastOneState = false;
 
                 foreach (var state in possibleStates)
@@ -260,14 +260,14 @@ namespace DynamicSystem.QueriesEvaluation
                     }
                     atLeastOneState = true;
                     bool result = AccessibilityQueryRecursion(newVisitedStates, state, transitionFunction, query);
-                    if (!result)
+                    if (result)
                     {
-                        fromEveryStateThereIsAPathToPositiveEnding = false;
+                        thereIsAPathToPositiveEnding = true;
                         break;
                     }
                 }
 
-                if (fromEveryStateThereIsAPathToPositiveEnding && atLeastOneState)
+                if (thereIsAPathToPositiveEnding && atLeastOneState)
                 {
                     atLeastOneActionLeadsToPositiveEnding = true;
                     break;

--- a/src/ConcurrentActions/Test/QueryResolver/NoninertialTest.cs
+++ b/src/ConcurrentActions/Test/QueryResolver/NoninertialTest.cs
@@ -1,0 +1,77 @@
+﻿using System.Linq;
+using FluentAssertions;
+using Model;
+using Model.ActionLanguage;
+using Model.Forms;
+using Model.QueryLanguage;
+using NUnit.Framework;
+
+namespace Test.QueryResolver
+{
+    [TestFixture]
+    public class NoninertialTest
+    {
+        private Signature signature;
+        private ActionDomain actionDomain;
+        private QuerySet querySet;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var aF = new Fluent("a");
+            var bF = new Fluent("b");
+            var cF = new Fluent("c");
+
+            var doA = new Action("doA");
+            var doB = new Action("doB");
+
+            signature = new Signature(
+                new[] {aF, bF, cF},
+                new[] {doA, doB}
+            );
+
+            var a = new Literal(aF);
+            var notA = new Literal(aF, true);
+            var b = new Literal(bF);
+
+            actionDomain = new ActionDomain();
+
+            // doA causes a if b
+            actionDomain.EffectStatements.Add(
+                new EffectStatement(doA, b, a)
+            );
+
+            // initially ~a
+            actionDomain.InitialValueStatements.Add(
+                new InitialValueStatement(notA)
+            );
+
+            // doB releases b
+            actionDomain.FluentReleaseStatements.Add(
+                new FluentReleaseStatement(doB, bF)
+            );
+
+            // noninertial c
+            actionDomain.FluentSpecificationStatements.Add(
+                new FluentSpecificationStatement(cF)
+            );
+
+            querySet = new QuerySet();
+
+            // accessible a
+            querySet.AccessibilityQueries.Add(
+                new AccessibilityQuery(a)
+            );
+        }
+
+        [Test]
+        public void RunSystem()
+        {
+            // given all of the above
+            // when
+            var queryResolution = DynamicSystem.QueryResolver.ResolveQueries(signature, actionDomain, querySet);
+            // then
+            queryResolution.AccessibilityQueryResults.First().Item2.Should().BeTrue();
+        }
+    }
+}

--- a/src/ConcurrentActions/Test/Test.csproj
+++ b/src/ConcurrentActions/Test/Test.csproj
@@ -83,6 +83,7 @@
     <Compile Include="DNF\Visitors\SimplifyingFormulaVisitorTest.cs" />
     <Compile Include="DNF\Visitors\VisitorTestUtils.cs" />
     <Compile Include="NewGeneration\NewGenerationLightTest.cs" />
+    <Compile Include="QueryResolver\NoninertialTest.cs" />
     <Compile Include="QueryResolver\ProducerConsumerTest.cs" />
     <Compile Include="MinimizeNew\TestCases\ITransitionFunctionGenerationTestCase.cs" />
     <Compile Include="MinimizeNew\TestCases\ProducerAndConsumerTransitionFunctionGenerationTestCase.cs" />


### PR DESCRIPTION
(closes #43)

Gdy ewaluujemy kwerendę **accessible**, wystarczy że na każdym kroku rekursji istnieje jedna ścieżka prowadząca do osiągnięcia celu (niekoniecznie z każdego stanu osiągalnego musi taka ścieżka istnieć)